### PR TITLE
Feat(restore): Add possibility to restore from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ SELECTORS:
         TODO: handle multiple results. Currently fails in such case.
 
   --archived-vm-name <name_label>
-        Name used as prefix in the S3 bucket, to identify VM.
+        Name used as prefix in the S3 bucket, to identify a VM.
         That name was the one printed in the GUI of XO.
         E.g: --archived-vm-name foo-bar-01
         This is different from --vm-name because the VM does not currently exist in XO and

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ COMMANDS:
             ├── SR-ID.txt
             └── VM.json
 
+  pull
+        Pulls archived files (XVA+metadata) from S3.
+        To be used with --archived-vm-name
+        S3 bucket name should be define as an envvar, see below CONFIG FILE section.
+        Files under "s3://bucket_name/$ARCHIVED-VM-NAME/" will be copied locally, like:
+            foo-bar-01
+            ├── 622870c0-0d21-286b-df2d-05ff2bab6a45.xva
+            ├── SR-ID.txt
+            └── VM.json
+
   delete
         Deletes the Virtual Machine and its associated disks in XOA
         To be used with --vm-id or --vm-name
@@ -56,6 +66,20 @@ COMMANDS:
         and deleting the VM thus created. VM will stay in Halted state all along.
         To be used with --sr-id and --xva-file
 
+  restore
+        Call those commands, in this order: pull, get-metadata-from-local-files, import and clean
+        To be used with --archived-vm-name
+
+  get-metadata-from-local-files
+        Checks that local files contain mandatory informations: SR-ID and a readable XVA-file.
+        To be used with --archived-vm-name or --vm-id or --vm-name
+
+  clean
+        Removes local files associated with the provided selector inside LOCAL_TMP_DIR
+        This script handles local files properly, but in case of an error,
+        it may be necessary to run this command.
+        To be used with --archived-vm-name or --vm-id or --vm-name
+
 
 SELECTORS:
   --vm-id <id>
@@ -68,6 +92,13 @@ SELECTORS:
         E.g: --vm-name foo-bar-01
         If used in conjunction with --vm-id, then will be ignored
         TODO: handle multiple results. Currently fails in such case.
+
+  --archived-vm-name <name_label>
+        Name used as prefix in the S3 bucket, to identify VM.
+        That name was the one printed in the GUI of XO.
+        E.g: --archived-vm-name foo-bar-01
+        This is different from --vm-name because the VM does not currently exist in XO and
+        therefore the two workflows are totally different, as is the name of this selector.
 
   --sr-id <id>
         The ID of XO's Storage Repository where to import the VM.

--- a/xo-archiver
+++ b/xo-archiver
@@ -68,6 +68,20 @@ COMMANDS:
         and deleting the VM thus created. VM will stay in Halted state all along.
         To be used with --sr-id and --xva-file
 
+  restore
+        Call those commands, in this order: pull, get-metadata-from-local-files, import and clean
+        To be used with --archived-vm-name
+
+  get-metadata-from-local-files
+        Checks that local files contain mandatory informations: SR-ID and a readable XVA-file.
+        To be used with --archived-vm-name or --vm-id or --vm-name
+
+  clean
+        Removes local files associated with the provided selector inside LOCAL_TMP_DIR
+        This script handles local files properly, but in case of an error,
+        it may be necessary to run this command.
+        To be used with --archived-vm-name or --vm-id or --vm-name
+
 
 SELECTORS:
   --vm-id <id>
@@ -311,6 +325,17 @@ function create_working_dir {
 }
 
 
+# Usage: clean_working_dir
+# Cleans the temporary directory
+function clean_working_dir {
+    if [[ -d "$WORKING_DIR" ]]
+    then
+        log "Cleaning $WORKING_DIR/"
+        rm -Rf $WORKING_DIR/
+    fi
+}
+
+
 # Usage: export_vm <VM-ID>
 # Will exports the specified VM in compressed zstd, in a .xva file
 function export_vm {
@@ -329,7 +354,7 @@ function export_vm {
     then
         log "Export completed at \"$_vm_export_path\""
         # this exported envvar is used in Main to call temporarily_restores_xva function
-        export EXPORTED_VM_XVA_FILE=$_vm_export_path
+        export VM_XVA_FILE=$_vm_export_path
     else
         rm -f $_vm_export_path
         die "Export failed for VM \"${1}\""
@@ -372,15 +397,15 @@ function export_metadata {
     # get first SR from VDIs and check if result looks good
     grep --no-filename -E "[a-Z0-9]" $WORKING_DIR/VDI-*-SR-ID.txt | head -1 > $WORKING_DIR/SR-ID.txt
     # this exported envvar is used in Main to call temporarily_restores_xva function
-    export EXPORTED_VM_SR_ID="$(cat $WORKING_DIR/SR-ID.txt)"
+    export VM_SR_ID="$(cat $WORKING_DIR/SR-ID.txt)"
 
-    if echo $EXPORTED_VM_SR_ID | grep -q "[a-Z0-9]"
+    if echo $VM_SR_ID | grep -q "[a-Z0-9]"
     then
         rm -f $WORKING_DIR/VDI-*-SR-ID.txt
-        log "Storage Repository ID \"$EXPORTED_VM_SR_ID\" exported to $WORKING_DIR/SR-ID.txt"
+        log "Storage Repository ID \"$VM_SR_ID\" exported to $WORKING_DIR/SR-ID.txt"
     else
         rm -f $WORKING_DIR/{SR-ID.txt,VDI-*-SR-ID.txt}
-        unset $EXPORTED_VM_SR_ID
+        unset $VM_SR_ID
         die "Unable to export Storage Repository ID for VM \"$1\""
     fi
 }
@@ -462,8 +487,7 @@ function copy_to_s3 {
     if aws s3 cp $WORKING_DIR/ $_remote_xva_path/ --recursive
     then
         log "Successfully copied exports of \"$_vm_name\" on bucket \"$AWS_BUCKET_XO_ARCHIVES\""
-        log "Cleaning up $WORKING_DIR/"
-        rm -Rf $WORKING_DIR/
+        clean_working_dir
     else
         die "Fail to push to s3"
     fi
@@ -489,20 +513,59 @@ function copy_from_s3 {
     local _remote_xva_path="s3://$AWS_BUCKET_XO_ARCHIVES/$1"
     log "Copying archives from \"$_remote_xva_path\" into $WORKING_DIR/"
 
-    if aws s3 cp $_remote_xva_path/ $WORKING_DIR/ --recursive
+    if aws s3 cp $_remote_xva_path/ $WORKING_DIR/ --recursive --force-glacier-transfer
     then
         if ls -A $WORKING_DIR/ | grep -q "[a-Z0-9]"
         then
             log "Successfully copied files from bucket \"$_remote_xva_path\" into $WORKING_DIR/"
         else
-            log "Cleaning up $WORKING_DIR/"
-            rm -Rf $WORKING_DIR/
+            clean_working_dir
             die "Nothing to copy from S3, ensure \"$_remote_xva_path\" exists and contains files"
         fi
     else
-        log "Cleaning up $WORKING_DIR/"
-        rm -Rf $WORKING_DIR/
+        clean_working_dir
         die "Fail to copy from S3"
+    fi
+}
+
+
+# Usage: get_metadata_from_local_files
+# Checks that local files contain mandatory informations
+# and exports vars for futur import: SR-ID and a readable XVA-file
+# This function doesn't need argument as $WORKING_DIR is used
+# and this var depends of the selector used to load this script
+function get_metadata_from_local_files {
+    if ! ls -A $WORKING_DIR/ | grep -q "[a-Z0-9]"
+    then
+        die "No file found in local directory \"$WORKING_DIR/\""
+    fi
+
+    # this exported envvar is used in Main to call import_vm when restoring
+    export VM_SR_ID="$(cat $WORKING_DIR/SR-ID.txt 2>/dev/null)"
+
+    if echo $VM_SR_ID | grep -q "[a-Z0-9]"
+    then
+        log "Found Storage Repository ID \"$VM_SR_ID\" from file $WORKING_DIR/SR-ID.txt"
+    else
+        unset $VM_SR_ID
+        die "Unable to export Storage Repository ID from file $WORKING_DIR/SR-ID.txt"
+    fi
+
+    # Try to get xva file from VM.json
+    local _archived_vm_id=$(cat $WORKING_DIR/VM.json 2>/dev/null | jq -r --exit-status '.[0].id')
+    if echo $_archived_vm_id | grep -q "[a-Z0-9]"
+    then
+        local _archived_vm_xva_file="$WORKING_DIR/${_archived_vm_id}.xva"
+        if [[ -r "$_archived_vm_xva_file" ]]
+        then
+            # this exported envvar is used in Main to call import_vm when restoring
+            export VM_XVA_FILE="$_archived_vm_xva_file"
+            log "Found XVA file \"$VM_XVA_FILE\""
+        else
+            die "Unable to find XVA file from metadata"
+        fi
+    else
+        die "Unable to get VM-ID from $WORKING_DIR/VM.json"
     fi
 }
 
@@ -592,7 +655,7 @@ case "$command" in
     archive)
         export_vm $vm_id
         export_metadata $vm_id
-        temporarily_restores_xva $EXPORTED_VM_SR_ID $EXPORTED_VM_XVA_FILE
+        temporarily_restores_xva $VM_SR_ID $VM_XVA_FILE
         copy_to_s3 $vm_id
         delete_vm $vm_id
         ;;
@@ -607,6 +670,19 @@ case "$command" in
         ;;
     pull)
         copy_from_s3 $archived_vm_name
+        get_metadata_from_local_files
+        ;;
+    restore)
+        copy_from_s3 $archived_vm_name
+        get_metadata_from_local_files
+        import_vm $VM_SR_ID $VM_XVA_FILE
+        clean_working_dir
+        ;;
+    get-metadata-from-local-files)
+        get_metadata_from_local_files
+        ;;
+    clean)
+        clean_working_dir
         ;;
     * )
         die "Unknown command \"$command\""

--- a/xo-archiver
+++ b/xo-archiver
@@ -39,6 +39,16 @@ COMMANDS:
             ├── SR-ID.txt
             └── VM.json
 
+  pull
+        Pulls archived files (XVA+metadata) from S3.
+        To be used with --archived-vm-name
+        S3 bucket name should be define as an envvar, see below CONFIG FILE section.
+        Files under "s3://bucket_name/\$ARCHIVED-VM-NAME/" will be copied locally, like:
+            foo-bar-01
+            ├── 622870c0-0d21-286b-df2d-05ff2bab6a45.xva
+            ├── SR-ID.txt
+            └── VM.json
+
   delete
         Deletes the Virtual Machine and its associated disks in XOA
         To be used with --vm-id or --vm-name
@@ -70,6 +80,13 @@ SELECTORS:
         E.g: --vm-name foo-bar-01
         If used in conjunction with --vm-id, then will be ignored
         TODO: handle multiple results. Currently fails in such case.
+
+  --archived-vm-name <name_label>
+        Name used as prefix in the S3 bucket, to identify VM.
+        That name was the one printed in the GUI of XO.
+        E.g: --archived-vm-name foo-bar-01
+        This is different from --vm-name because the VM does not currently exist in XO and
+        therefore the two workflows are totally different, as is the name of this selector.
 
   --sr-id <id>
         The ID of XO's Storage Repository where to import the VM.
@@ -167,6 +184,9 @@ do
                                             ;;
         --vm-name )                         shift
                                             vm_name="$1"
+                                            ;;
+        --archived-vm-name )                shift
+                                            archived_vm_name="$1"
                                             ;;
         --sr-id )                           shift
                                             sr_id="$1"
@@ -450,6 +470,43 @@ function copy_to_s3 {
 }
 
 
+# Usage: copy_from_s3 <VM-NAME>
+# copies the <VM-NAME> corresponding files from the s3 bucket specified through envvar
+function copy_from_s3 {
+    if [[ -z $1 ]]
+    then
+        die "copy_from_s3 needs parameter: VM-NAME. E.g: foo-bar-01"
+    fi
+
+    # ensure bucket var is set
+    if [[ -z "$AWS_BUCKET_XO_ARCHIVES" ]]
+    then 
+        die "Bucket is undefined. look at the --help and search for AWS_BUCKET_XO_ARCHIVES"
+    fi
+
+    create_working_dir
+
+    local _remote_xva_path="s3://$AWS_BUCKET_XO_ARCHIVES/$1"
+    log "Copying archives from \"$_remote_xva_path\" into $WORKING_DIR/"
+
+    if aws s3 cp $_remote_xva_path/ $WORKING_DIR/ --recursive
+    then
+        if ls -A $WORKING_DIR/ | grep -q "[a-Z0-9]"
+        then
+            log "Successfully copied files from bucket \"$_remote_xva_path\" into $WORKING_DIR/"
+        else
+            log "Cleaning up $WORKING_DIR/"
+            rm -Rf $WORKING_DIR/
+            die "Nothing to copy from S3, ensure \"$_remote_xva_path\" exists and contains files"
+        fi
+    else
+        log "Cleaning up $WORKING_DIR/"
+        rm -Rf $WORKING_DIR/
+        die "Fail to copy from S3"
+    fi
+}
+
+
 # Usage: temporarily_restores_xva <SR-ID> <XVA-local-path>
 # Will restore the XVA in the specified SR and delete this newly created VM right away
 function temporarily_restores_xva {
@@ -507,6 +564,10 @@ then
         _return_value=$?
         if [[ $_return_value -gt 0 ]]; then exit $_return_value; fi
     # no vm_id or vm_name
+    elif [[ ! -z $archived_vm_name ]]
+    then
+        # VM doesn't exist, we retrieve archived files from S3 (no vm_id to find)
+        WORKING_DIR="$LOCAL_TMP_DIR/$archived_vm_name"
     elif [[ -z $sr_id ]] || [[ -z $xva_file ]]
     then
         # no selector provided
@@ -515,7 +576,7 @@ then
 fi
 
 
-WORKING_DIR="$LOCAL_TMP_DIR/$vm_id"
+WORKING_DIR="${WORKING_DIR:-$LOCAL_TMP_DIR/$vm_id}"
 
 log "Script command=\"$command\""
 
@@ -543,6 +604,9 @@ case "$command" in
         ;;
     temporarily-restores-xva)
         temporarily_restores_xva $sr_id $xva_file
+        ;;
+    pull)
+        copy_from_s3 $archived_vm_name
         ;;
     * )
         die "Unknown command \"$command\""

--- a/xo-archiver
+++ b/xo-archiver
@@ -96,7 +96,7 @@ SELECTORS:
         TODO: handle multiple results. Currently fails in such case.
 
   --archived-vm-name <name_label>
-        Name used as prefix in the S3 bucket, to identify VM.
+        Name used as prefix in the S3 bucket, to identify a VM.
         That name was the one printed in the GUI of XO.
         E.g: --archived-vm-name foo-bar-01
         This is different from --vm-name because the VM does not currently exist in XO and


### PR DESCRIPTION
Added:

* command `pull`, to be able to copy a file from S3 (even glacier), locally
* command `get-metadata-from-local-files`, to check local files and get metadata from them (needed after pull and before restore)
* command `restore`, to restore a VM from S3 by its archived-name
* command `clean`, to clean LOCAL_TMP_DIR  of particular selector files (needed after the end of the restoration)
* selector `--archived-vm-name`, to differentiate from an archived VM that doesn't exist on XO from an existing VM

Changed:
* EXPORTED_VM_XVA_FILE has been replaced by VM_XVA_FILE (because this var can also be needed in other situations than exports)
* EXPORTED_VM_SR_ID has been replaced by VM_SR_ID (because this var can also be needed in other situations than exports)

